### PR TITLE
Hotfix/add missing source value

### DIFF
--- a/rmf_human_detector_oakd/launch/human_detector.launch.xml
+++ b/rmf_human_detector_oakd/launch/human_detector.launch.xml
@@ -3,7 +3,7 @@
 <launch>
   <arg name="blob_path" default="" description="The absolute filepath to the NN blob"/>
   <arg name="sync_nn" default="True" description="Whether to sync the depth and preview frames before making inference"/>
-  <arg name="detector_name" default="rmf_human_detector_oakd" description="The name given to this detector"/>
+  <arg name="detector_name" default="rmf_human_detector_oakd" description="The name given to this detector, used for obstacle topic's source value"/>
   <arg name="frame_id" default="oakd_camera_link" description="The frame ID for the camera"/>
   <arg name="level_name" default="L1" description="The level or map on which the camera is located"/>
   <arg name="obstacle_classification" default="human" description="The classification to be used to report human obstacles"/>

--- a/rmf_human_detector_oakd/launch/human_detector.launch.xml
+++ b/rmf_human_detector_oakd/launch/human_detector.launch.xml
@@ -6,7 +6,7 @@
   <arg name="detector_name" default="rmf_human_detector_oakd" description="The name given to this detector"/>
   <arg name="frame_id" default="oakd_camera_link" description="The frame ID for the camera"/>
   <arg name="level_name" default="L1" description="The level or map on which the camera is located"/>
-  <arg name="obstacle_classification" default="human" description="The classificaation to be used to report human obstacles"/>
+  <arg name="obstacle_classification" default="human" description="The classification to be used to report human obstacles"/>
   <arg name="debug" default="false" description="If True, the detection results will be visualized"/>
   <arg name="rmf_frame_id" default="map" description="The frame_id w.r.t which RMF coordinates are defined"/>
   <arg name="x" default="0" description="x translation between RMF and camera frames"/>

--- a/rmf_human_detector_oakd/src/HumanDetector.cpp
+++ b/rmf_human_detector_oakd/src/HumanDetector.cpp
@@ -270,7 +270,7 @@ HumanDetector::HumanDetector(
           obstacle.header.frame_id = data->frame_id;
           // TODO(YV): Stamp
           obstacle.id = obstacle_count;
-          obstacle.id = obstacle_count;
+          obstacle.source = data->detector_name;
           obstacle.level_name = data->level_name;
           obstacle.classification = data->obstacle_classification;
           obstacle.bbox.center.position.x = spatial_x;

--- a/rmf_human_detector_oakd/src/HumanDetector.cpp
+++ b/rmf_human_detector_oakd/src/HumanDetector.cpp
@@ -38,7 +38,7 @@ HumanDetector::HumanDetector(
     "/rmf_obstacles",
     10);
 
-  // Declare prameters
+  // Declare parameters
   RCLCPP_INFO(
     this->get_logger(),
     "Configuring rmf_human_detector_oakd...");


### PR DESCRIPTION
## Bug fix

There was an issue in the code where the obstacle information was published within the `rmf_human_detector_oakd` package. The `obstacle.id` value was mistakenly inserted twice, leaving the `obstacle.source` field empty. 

As a result, the `rmf_visualization_obstacles` node ignored the published obstacle, preventing it from being displayed in rviz.
https://github.com/open-rmf/rmf_visualization/blob/1130f2cc491736f7dc395abe032d364008c24900/rmf_visualization_obstacles/src/ObstacleVisualizer.cpp#L74-L80

It appears that the `detector_name` parameter was intended to be used as the source value in the obstacle information being published, so I made the necessary modifications.
