### PR TITLE
Fix/laneblocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Subsequently, any changes to the surroundings are detected as an obstacle.
 
 To run
 ```
-ros2 run rmf_obstacle_detector_laserscan laserscan_detector
+ros2 launch rmf_obstacle_detector_laserscan laserscan_detector.launch.xml
 ```
 To configure and Activate
 ```

--- a/README.md
+++ b/README.md
@@ -94,3 +94,19 @@ To run:
 ```bash
 ros2 run rmf_obstacle_ros2 lane_blocker_node
 ```
+<!-- This table has been generated using Copilot v1.35.0 with Claude Sonnet 4 -->
+The node accepts the following parameters
+
+| Parameter | Default Value | Description |
+|-----------|---------------|-------------|
+| `rmf_frame_id` | `"map"` | Reference frame for RMF coordinate system |
+| `obstacle_lane_threshold` | `0.25` | Distance threshold (meters) for considering an obstacle in vicinity of a lane |
+| `lane_width` | `0.5` | Width of lanes (meters) used for collision geometry calculations |
+| `tf2_lookup_duration` | `0.5` | Maximum duration (seconds) to wait for TF2 transform lookups |
+| `process_rate` | `1.0` | Frequency (Hz) at which obstacle processing occurs |
+| `cull_rate` | `0.1` | Frequency (Hz) at which expired obstacles are removed |
+| `max_search_millis` | `1000` | Maximum time (milliseconds) to spend searching for lane-obstacle intersections |
+| `continuous_checker` | `true` | Whether to continuously re-check obstacle-lane associations |
+| `lane_closure_threshold` | `1` | Minimum number of obstacles required to close a lane |
+| `speed_limit_threshold` | `3` | Minimum number of obstacles required to apply speed limits to a lane |
+| `speed_limit` | `0.5` | Speed limit (m/s) applied to lanes when speed limiting is triggered |

--- a/rmf_obstacle_detector_laserscan/CMakeLists.txt
+++ b/rmf_obstacle_detector_laserscan/CMakeLists.txt
@@ -58,4 +58,9 @@ install(
   ARCHIVE DESTINATION lib
 )
 
+install(
+  DIRECTORY launch/
+  DESTINATION share/${PROJECT_NAME}/launch
+)
+
 ament_package()

--- a/rmf_obstacle_detector_laserscan/launch/laserscan_detector.launch.xml
+++ b/rmf_obstacle_detector_laserscan/launch/laserscan_detector.launch.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- LaserScan obstacle detector -->
+  <node
+    pkg="rmf_obstacle_detector_laserscan"
+    exec="laserscan_detector"
+    name="laserscan_obstacle_detector"
+    output="screen"
+    >
+    <param name="use_sim_time" value="false"/>
+  </node>
+
+  <!-- Use your local lidar reference frame -->
+  <node
+    pkg="tf2_ros"
+    exec="static_transform_publisher"
+    name="static_tf_map_lidar"
+    output="screen"
+    args="--x 0 --y 0 --z 0 --roll 0 --pitch 0 --yaw 0 --frame-id sim_world --child-frame-id lidar">
+  </node>
+
+  <node
+    pkg="ros_gz_bridge"
+    exec="parameter_bridge"
+    name="ros_gz_bridge_laserscan"
+    output="screen"
+    args="/lidar/scan@sensor_msgs/msg/LaserScan@gz.msgs.LaserScan">
+  </node>
+
+</launch>

--- a/rmf_obstacle_detector_laserscan/src/LaserscanDetector.cpp
+++ b/rmf_obstacle_detector_laserscan/src/LaserscanDetector.cpp
@@ -300,7 +300,8 @@ void LaserscanDetector::process()
     this->get_logger(),
     "## Processing latest_scan with angle_min: %.2f, angle_max: %.2f, angle_increment: %.6f, "
     "range_min: %.2f, range_max: %.2f, #ranges: %ld",
-    _latest_scan->angle_min, _latest_scan->angle_max, _latest_scan->angle_increment,
+    _latest_scan->angle_min, _latest_scan->angle_max,
+    _latest_scan->angle_increment,
     _latest_scan->range_min, _latest_scan->range_max,
     _latest_scan->ranges.size()
   );

--- a/rmf_obstacle_detector_laserscan/src/LaserscanDetector.cpp
+++ b/rmf_obstacle_detector_laserscan/src/LaserscanDetector.cpp
@@ -116,6 +116,7 @@ auto LaserscanDetector::on_configure(const State& /*previous_state*/)
 
   RCLCPP_INFO(
     this->get_logger(), "Done configuring!");
+
   return CallbackReturn::SUCCESS;
 }
 
@@ -185,6 +186,12 @@ LaserscanDetector::LaserscanDetector(const rclcpp::NodeOptions& options)
 : LifecycleNode("laserscan_obstacle_detector", options),
   _calibrated(false)
 {
+  const bool use_sim_time = this->get_parameter("use_sim_time").as_bool();
+  RCLCPP_INFO(
+    this->get_logger(),
+    "use_sim_time parameter is set to %s", use_sim_time ? "true" : "false"
+  );
+
   _range_threshold = this->declare_parameter("range_threshold", 1.0);
   RCLCPP_INFO(
     this->get_logger(),

--- a/rmf_obstacle_detector_laserscan/src/LaserscanDetector.cpp
+++ b/rmf_obstacle_detector_laserscan/src/LaserscanDetector.cpp
@@ -407,6 +407,7 @@ void LaserscanDetector::process()
     msg->obstacles.push_back(std::move(obstacle));
     ++id;
   }
+  msg->header.frame_id = _latest_scan->header.frame_id;
   _obs_pub->publish(std::move(msg));
 }
 

--- a/rmf_obstacle_ros2/src/lane_blocker/LaneBlocker.cpp
+++ b/rmf_obstacle_ros2/src/lane_blocker/LaneBlocker.cpp
@@ -106,7 +106,13 @@ LaneBlocker::LaneBlocker(const rclcpp::NodeOptions& options)
       std::make_shared<tf2_ros::TransformListener>(*_tf2_buffer);
   }
 
-  _rmf_frame = this->declare_parameter("rmf_frame_id", "map");
+  const bool use_sim_time = this->get_parameter("use_sim_time").as_bool();
+  RCLCPP_INFO(
+    this->get_logger(),
+    "use_sim_time parameter is set to %s", use_sim_time ? "true" : "false"
+  );
+
+  _rmf_frame = this->declare_parameter("rmf_frame_id", "sim_world");
   RCLCPP_INFO(
     this->get_logger(),
     "Setting parameter rmf_frame_id to %s", _rmf_frame.c_str()

--- a/rmf_obstacle_ros2/src/lane_blocker/LaneBlocker.cpp
+++ b/rmf_obstacle_ros2/src/lane_blocker/LaneBlocker.cpp
@@ -157,7 +157,8 @@ LaneBlocker::LaneBlocker(const rclcpp::NodeOptions& options)
     this->declare_parameter("continuous_checker", true);
   RCLCPP_INFO(
     this->get_logger(),
-    "Setting parameter continuous_checker to %s", _continuous_checker ? "true" : "false"
+    "Setting parameter continuous_checker to %s",
+    _continuous_checker ? "true" : "false"
   );
 
   _lane_closure_threshold =
@@ -472,17 +473,21 @@ void LaneBlocker::process()
             if (intersect)
             {
               std::cout << "Obstacle position in RMF frame: ["
-                    << o2.center.x << ", "
-                    << o2.center.y << ", "
-                    << o2.center.theta << "]" << std::endl;
-  
+                        << o2.center.x << ", "
+                        << o2.center.y << ", "
+                        << o2.center.theta << "]" << std::endl;
+
               std::cout << "Fleet: " << fleet_name
-                    << ", Lane: " << i
-                    << ", o1(center: [" << o1.center.x << ", " << o1.center.y << ", " << o1.center.theta << "], size_x: " << o1.size_x << ", size_y: " << o1.size_y << ")"
-                    << ", o2(center: [" << o2.center.x << ", " << o2.center.y << ", " << o2.center.theta << "], size_x: " << o2.size_x << ", size_y: " << o2.size_y << ")"
-                    << ", how_much: " << how_much
-                    << ", intersect: " << intersect
-                    << std::endl;
+                        << ", Lane: " << i
+                        << ", o1(center: [" << o1.center.x << ", " <<
+                o1.center.y << ", " << o1.center.theta << "], size_x: " <<
+                o1.size_x << ", size_y: " << o1.size_y << ")"
+                        << ", o2(center: [" << o2.center.x << ", " <<
+                o2.center.y << ", " << o2.center.theta << "], size_x: " <<
+                o2.size_x << ", size_y: " << o2.size_y << ")"
+                        << ", how_much: " << how_much
+                        << ", intersect: " << intersect
+                        << std::endl;
             }
             #endif
             if (intersect || how_much < threshold)


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

- The node `laserscan_detector` kept generating such messages:
``Message Filter dropping message: frame '' at time 0.000 for reason 'the frame id of the message is empty`` 

- The node `lane_blocker_node` was not publishing the lane closure requests correctly

### Fix applied

- I filled the message `header.frame_id` with `_latest_scan->header.frame_id` as suggested by @Yadunund in [issue #9](https://github.com/open-rmf/rmf_obstacle/issues/9#issuecomment-1411443959)
- I rewrote the logic for associating obstacles to the lanes

Furthermore, I changed the obstacle transform time to `rclcpp::Time(obstacle.header.stamp)` as that's the most accurate timestamp, instead of `tf2::TimePointZero` which is the last available

<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->



### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [x] I used a GenAI tool in this PR. 
- [ ] I did not use GenAI

I used Copilot v1.35.0 and Claude Sonnet 4 to generate the parameter table in the README